### PR TITLE
Fixes to reminders

### DIFF
--- a/MHTimer.js
+++ b/MHTimer.js
@@ -686,7 +686,7 @@ function doRemind (timer) {
                     .then((user) => {
                 // console.log("Got a user of " + typeof user + " when I tried with " + remind.user + " for " + remind.area);
                 if (typeof user !== 'object') {
-                    remind.fail += 1;
+                    remind.fail = (remind.fail || 0) + 1;
                     return;
                 }
                 if (remind.count > 0) {
@@ -720,11 +720,11 @@ function doRemind (timer) {
                 }
                 user.send(timer.getAnnounce() + "\n" + usage_str )
                     .then(function() { err = 0; remind.fail = 0; }, //worked
-                        function() { err = 1; remind.fail += 1; });
+                        function() { err = 1; remind.fail = (remind.fail || 0) + 1; });
                 // If err=1 then delete the timer because the user blocked the bot
             })
             .catch((err) => {
-                remind.fail += 1;
+                remind.fail = (remind.fail || 0) + 1;
             });
         }
     }
@@ -926,6 +926,9 @@ function listRemind(message) {
             }
             timer_str += ". " + usage_str + " stop` to turn off\n";
             found++;
+            if (remind.fail) {
+                timer_str += "There have been " + remind.fail + " failed attempts to remind you of this one.\n";
+            }
         }
     }
     var err = 0;


### PR DESCRIPTION
Reminders would unset on one failure, now will fail up to 10 times and you can get your current count. Reminders also incorrectly failed because users weren't cached - so the bot hadn't seen the user since a boot.