### PR TITLE
Rework I/O and bot startup

### DIFF
--- a/timerClass.js
+++ b/timerClass.js
@@ -32,13 +32,13 @@ class Timer {
     constructor(seed) {
         if (!seed)
             throw new TypeError("Timer construction requires an input seed object.");
-        
+
         // If the input Timer seed is a primitive (e.g. 1), or is missing required properties, bail. 
         const keys = Object.keys(seed);
         const required = ['area', 'seed_time', 'repeat_time'];
         // If a required key is missing, or has a falsy value, then the seed is invalid.
         if (!keys.length || !required.every(rq => (keys.indexOf(rq) !== -1 && seed[rq])))
-            throw new TypeError(`Input timer seed is missing required keys. Found only: ${keys.toString()}`);
+            throw new TypeError(`Input timer seed is missing required keys or values. Require values for keys "${required.join(`", "`)}".`);
 
         // Assign area and sub_area.
         this._area = String(seed.area);
@@ -48,16 +48,16 @@ class Timer {
         // Validate and assign time values.
         this._seedTime = DateTime.fromISO(seed.seed_time); // Are they ISO format? or something else?
         if (!this._seedTime.isValid)
-            throw new TypeError(`(${this.name}): Input seed time ${seed.seed_time} failed to parse into a valid DateTime.`);
+            throw new TypeError(`(${this.name}): Input seed time "${seed.seed_time}" failed to parse into a valid DateTime.`);
 
         // Create the Duration that represents the time period between activations.
         this._repeatDuration = getAsDuration(seed.repeat_time || 0, true);
         if (this._repeatDuration.as('minutes') < 1)
-            throw new RangeError(`(${this.name}): Input repeat duration is ${seed.repeat_time} (invalid or too short).`);
+            throw new RangeError(`(${this.name}): Input repeat duration is "${seed.repeat_time}" (invalid or too short).`);
 
         // Require the stored seed time to be in the past.
         while (DateTime.utc() < this._seedTime) {
-            console.log(`(${this.name}): seed time ('${this._seedTime}') in future: decrementing ${this._repeatDuration.as('minutes')} minutes.`);
+            console.log(`(${this.name}): seed time ("${this._seedTime}") in future: decrementing ${this._repeatDuration.as('minutes')} minutes.`);
             this._seedTime = this._seedTime.minus(this._repeatDuration);
         }
 
@@ -295,7 +295,7 @@ class Timer {
 function getAsDuration(value, normalize = false) {
     let dur = _isLuxonObject(value) ? Duration.fromObject(value) : Duration.fromMillis(value || 0);
     if (!dur.isValid) {
-        console.log(`Received invalid input ${value} to convert to a Duration.`);
+        console.log(`Received invalid input "${value}" to convert to a Duration.`);
         dur = Duration.fromMillis(0);
         // throw new TypeError(`Invalid argument to Duration constructor: ${value}`);
     }

--- a/timerClass.js
+++ b/timerClass.js
@@ -238,21 +238,28 @@ class Timer {
         if (!key || !timeout)
             return;
         this.stopTimeout(key);
-    
+
         this._timeout[key] = timeout;
     }
 
     /**
      * Stops and also removes the existing Node.js Timer object for this timer instance
-     *
+     * If no key is given, all existing timeouts will be cleared.
      * @instance
-     * @param {string} key The channel and guild identifier for this particular timeout.
+     * @param {string} [key] The channel and guild identifier for this particular timeout.
      */
     stopTimeout(key) {
-        if (this._timeout[key])
-            clearTimeout(this._timeout[key]);
+        if (key) {
+            if (this._timeout[key])
+                clearTimeout(this._timeout[key]);
 
-        this._timeout[key] = null;
+            this._timeout[key] = null;
+        }
+        else {
+            for (let key in this._timeout)
+                clearTimeout(this._timeout[key]);
+            this._timeout = {};
+        }
     }
 
     /**
@@ -273,15 +280,23 @@ class Timer {
 
     /**
      * Stops and also removes the existing Node.js Timer object for this timer instance.
+     * If no key is given, all existing intervals will be cleared.
      *
      * @instance
-     * @param {string} key The channel and guild identifier for this particular interval.
+     * @param {string} [key] The channel and guild identifier for this particular interval.
      */
     stopInterval(key) {
-        if (this._interval[key])
-            clearInterval(this._interval[key]);
+        if (key) {
+            if (this._interval[key])
+                clearInterval(this._interval[key]);
 
-        this._interval[key] = null;
+            this._interval[key] = null;
+        }
+        else {
+            for (let key in this._interval)
+                clearInterval(this._interval[key]);
+            this._interval = {};
+        }
     }
 }
 


### PR DESCRIPTION
Rather than the mix of promise + callback we had with `fs.readFile`, this PR lets us use Promises the whole way through. We could go further, and use `request-promises-native`, but I think we're fine as is.

As a part of reworking the file I/O, I made the load and save commands accept an input path, but default to the previous values. I also separated the loading of the data from the processing of the data, i.e. allowing us to load the data in some other manner and hand it to the right processor, rather than require reading the data from a given file on disk. i.e., 1 step closer to allowing on-demand creation of a timer / "bulk" hunter data.

As a part of reworking the bot startup, I removed all the hard exits and instead let node exit when it's ready. This probably wasn't working previously because all the timeouts/intervals that were set up were keeping the node event loop active (and thus needing to force exit). I kept the previous behavior following a WebSocket Error, which is to quit, but I think we can safely remove that (in a future PR). In said PR, we probably want to ensure that any active timers are not reinitialized. For a WebSocket error, none of the Timers should need reinstantiation, nor should the channels need rebinding (though adding a check for channel deletion should probably be done at some point). Note that the bot's `ready` event fires after every successful reconnection.

For logs that get printed from request, I've switched the `response` print to its JSON output, as the private members were generally obfuscating the interesting parts. (Those HTTP error/response/body logs get large).