### PR TITLE
Remind once

### DIFF
--- a/MHTimer.js
+++ b/MHTimer.js
@@ -109,7 +109,7 @@ function Main() {
 
     // Bot configuration.
     a.then(() => {
-        client.on("ready", () => {
+        client.once("ready", () => {
             console.log("I am alive!");
 
             // Find all text channels on which to send announcements.

--- a/MHTimer.js
+++ b/MHTimer.js
@@ -240,8 +240,13 @@ function loadSettings(resolve, reject) {
         // Set defaults if they were not specified.
         if (!settings.linkConversionChannel)
             settings.linkConversionChannel = "larrys-freebies";
-        if (!settings.timedAnnouncementChannel)
-            settings.timedAnnouncementChannel = "timers";
+
+        if (!settings.timedAnnouncementChannels)
+            settings.timedAnnouncementChannels = ["timers"];
+        if (!Array.isArray(settings.timedAnnouncementChannels))
+            settings.timedAnnouncementChannels = settings.timedAnnouncementChannels.split(",").map(s => s.trim());
+        settings.timedAnnouncementChannels = new Set(settings.timedAnnouncementChannels);
+
         settings.botPrefix = settings.botPrefix ? settings.botPrefix.trim() : '-mh';
 
         console.log(`Settings: loaded ${Object.keys(settings).length} from '${main_settings_filename}'.`);

--- a/MHTimer.js
+++ b/MHTimer.js
@@ -126,6 +126,7 @@ function Main() {
 
             // Use one timeout per timer to manage default reminders and announcements.
             timers_list.forEach(timer => scheduleTimer(timer, announcables));
+            console.log(`Timers: Initialized ${timer_config.size} timers on channels ${announcables}.`);
 
             // If we disconnect and then reconnect, do not bother rescheduling the already-scheduled timers.
             client.on("ready", () => console.log("I am alive again!"));
@@ -310,7 +311,7 @@ function scheduleTimer(timer, channels) {
             doAnnounce(t);
         }, msUntilActivation, timer)
     );
-    timer_config[timer.id] = { active: true, channels: channels, inactiveChannels: [] };
+    timer_config.set(timer.id, { active: true, channels: channels, inactiveChannels: [] });
 }
 
 /**

--- a/settings.json.sample
+++ b/settings.json.sample
@@ -1,6 +1,8 @@
     {
         "token": "",
         "linkConversionChannel": "larrys-freebies",
-        "timedAnnouncementChannel": "timers",
+        "timedAnnouncementChannels": [
+          "timers"
+        ],
         "botPrefix": "-mh"
     }

--- a/timerClass.js
+++ b/timerClass.js
@@ -82,6 +82,9 @@ class Timer {
         this._timeout = {};
         /** @type {Object <string, NodeJS.Timer>} the NodeJS.Timer object created by NodeJS.setInterval() */
         this._interval = {};
+
+        // Set a unique id for this timer.
+        this._id = getId();
     }
 
     /**
@@ -92,6 +95,16 @@ class Timer {
      */
     get name() {
         return `${this._area}${this._subArea ? `: ${this._subArea}` : ""}`;
+    }
+
+    /**
+     * A uniquely-identifing property for this specific timer.
+     *
+     * @instance
+     * @returns {string} e.g. "1"
+     */
+    get id() {
+        return this._id;
     }
 
     /**
@@ -285,6 +298,26 @@ class Timer {
     }
 }
 
+/**
+ * Generator for timer identifiers
+ *
+ * @generator
+ */
+function* nextId() {
+    var id = 0;
+    while (true)
+        yield (id++).toString();
+}
+/** Reference to an instantiated generator */
+const id = nextId();
+/**
+ * Method to simplify timer identifier assignment
+ *
+ * @returns {string} a unique string identifier.
+ */
+function getId() {
+    return id.next().value;
+}
 /**
  * Convert the given input into a Duration object
  * @param {{} | number} value a value from a user/file to be cast to a duration.


### PR DESCRIPTION
 - Resolves issue with multi-guild bot sending multiple PMs for the same instance of a reminder
 - Resolves issue with bot sending the same user multiple PMs when the user has both a generic and specific reminder that match an activating timer (e.g. `remind spill 3` and `remind arch forever`)
 - Avoids reinitializing every timer if the client reconnects after a disconnect.