### PR TITLE
Find/IFind multiple matches, with reaction-based response handler

### DIFF
--- a/MHTimer.js
+++ b/MHTimer.js
@@ -1806,8 +1806,10 @@ function findMouse(channel, args, command) {
     }
     else if (matches.length === 1) {
         // Send the single result directly.
-        _getQueryResult(isDM, url, matches[0].match)
-            .then(result => channel.send(`I found one good result for '${args}':\n${result}`, { split: { prepend: '```', append: '```' } }));
+        _getQueryResult(isDM, matches[0].match, qsParams).then(
+            result => channel.send(`I found one good result for '${args}':\n${result}`, { split: { prepend: '```', append: '```' } }),
+            result => channel.send(result)
+        ).catch(err => console.log(err));
     }
     else {
         // Create reactions, and when the user uses the corresponding reaction, PM the data.
@@ -1834,15 +1836,18 @@ function findMouse(channel, args, command) {
             rc.on('collect', mr => {
                 // Fetch the response and send it to the user.
                 let match = matches.filter(m => m.emojiId === mr.emoji.identifier)[0];
-                if (match) _getQueryResult(true, url, match.match)
-                    .then(result => mr.users.last().send(result, { split: { prepend: '```', append: '```' } }));
+                if (match) _getQueryResult(true, match.match, qsParams).then(
+                    result => mr.users.last().send(result, { split: { prepend: '```', append: '```' } }),
+                    result => mr.users.last().send(result)
+                ).catch(err => console.log(err));
             }).on('end', () => rc.message.clearReactions().catch(() => rc.message.delete()));
         }).catch(err => console.log('Reactions: error setting reactions:\n', err));
 
         // Always send one result to the channel.
-        sent.then(() => _getQueryResult(isDM, url, matches[0].match)
-            .then(result => channel.send(result, { split: { prepend: '```', append: '```' } }))
-        );
+        sent.then(() => _getQueryResult(isDM, matches[0].match, qsParams).then(
+            result => channel.send(result, { split: { prepend: '```', append: '```' } }),
+            result => channel.send(result))
+        ).catch(err => console.log(err));
     }
 }
 
@@ -2000,8 +2005,10 @@ function findItem(channel, args, command) {
     }
     else if (matches.length === 1) {
         // Send the single result directly.
-        _getQueryResult(isDM, url, matches[0].match)
-            .then(result => channel.send(`I found one good result for '${args}':\n${result}`, { split: { prepend: '```', append: '```' } }));
+        _getQueryResult(isDM, matches[0].match, qsParams).then(
+            result => channel.send(`I found one good result for '${args}':\n${result}`, { split: { prepend: '```', append: '```' } }),
+            result => channel.sent(result)
+        ).catch(err => console.log(err));
     }
     else {
         // Create reactions, and when the user uses the corresponding reaction, PM the data.
@@ -2028,15 +2035,18 @@ function findItem(channel, args, command) {
             rc.on('collect', mr => {
                 // Fetch the response and send it to the user.
                 let match = matches.filter(m => m.emojiId === mr.emoji.identifier)[0];
-                if (match) _getQueryResult(true, url, match.match)
-                    .then(result => mr.users.last().send(result, { split: { prepend: '```', append: '```' } }));
+                if (match) _getQueryResult(true, match.match, qsParams).then(
+                    result => mr.users.last().send(result, { split: { prepend: '```', append: '```' } }),
+                    result => mr.users.last().send(result)
+                ).catch(err => console.log(err));
             }).on('end', () => rc.message.clearReactions().catch(() => rc.message.delete()));
         }).catch(err => console.log('Reactions: error setting reactions:\n', err));
 
         // Always send one result to the channel.
-        sent.then(() =>_getQueryResult(isDM, url, matches[0].match)
-            .then(result => channel.send(result, { split: { prepend: '```', append: '```' } }))
-        );
+        sent.then(() => _getQueryResult(isDM, matches[0].match, qsParams).then(
+            result => channel.send(result, { split: { prepend: '```', append: '```' } }),
+            result => channel.send(result))
+        ).catch(err => console.log(err));
     }
 }
 

--- a/MHTimer.js
+++ b/MHTimer.js
@@ -1620,6 +1620,48 @@ function getHelpMessage(tokens) {
  */
 
 /**
+ * Query @devjacksmith's database for information about the given "item"
+ *
+ * @param {'loot'|'mouse'} queryType The type of "item" whose data is requested.
+ * @param {DatabaseEntity} dbEntity Identifying information about the "item"
+ * @param {Object <string, string>} [options] Any additional querystring options that should be set
+ */
+function getQueriedData(queryType, dbEntity, options) {
+    // TODO: fetch each value once, cache, and try to first serve cached content.
+    if (!dbEntity || !dbEntity.id || !dbEntity.value)
+        return Promise.reject({ error: `Could not perform a '${queryType}' query`, response: null });
+    // Check cache
+    /**
+     * Replace with actual cache checking:
+     * let cache_result = Cache.get(queryType, dbEntity.id, options)
+     * if (cache_result)
+     *   return Promise.resolve(cache_result);
+     */
+
+    // No result in cache, requery.
+    return new Promise((resolve, reject) => {
+        let qsOptions = options || {};
+        qsOptions.item_type = queryType;
+        qsOptions.item_id = dbEntity.id;
+        let rq = request({
+            uri: 'https://mhhunthelper.agiletravels.com/searchByItem.php',
+            json: true,
+            qs: qsOptions
+        }, (error, response, body) => {
+            if (!error && response.statusCode === 200 && Array.isArray(body)) {
+                /**
+                 * Replace with actual cache storage:
+                 * Cache.put(queryType, dbEntity.id, options, body);
+                 */
+                resolve(body);
+            }
+            else
+                reject({ error: error, response: response });
+        });
+    });
+}
+
+/**
  * Initialize (or refresh) the known mice lists from @devjacksmith's tools.
  */
 function getMouseList() {

--- a/MHTimer.js
+++ b/MHTimer.js
@@ -1654,6 +1654,7 @@ function findMouse(channel, args, command) {
     //NOTE: RH location is https://mhhunthelper.agiletravels.com/tracker.json
     let url = 'https://mhhunthelper.agiletravels.com/searchByItem.php?item_type=mouse';
     let retStr = `'${args}' not found`;
+    let isDM = ['dm', 'group'].includes(channel.type);
 
     // Deep copy the input args, in case we modify them.
     const orig_args = JSON.parse(JSON.stringify(args));
@@ -1686,7 +1687,7 @@ function findMouse(channel, args, command) {
             `result` : `results`} for '${args}'. Here's the top result:`);
 
     matches.forEach((mouse, i) => {
-        if (i) return;
+        if (i && !isDM) return;
         let id = mouse.id,
             name = mouse.value,
             query = url + `&item_id=${id}`;
@@ -1720,8 +1721,7 @@ function findMouse(channel, args, command) {
                 // Sort that by Attraction Rate, descending.
                 attractions.sort((a, b) => (b.rate - a.rate));
                 // Keep only the top 10 results, unless this is a DM.
-                if (channel.type !== 'dm')
-                    attractions.splice(10);
+                attractions.splice(isDM ? 10 : 100);
 
                 // Column Formatting specification.
                 /** @type {Object <string, ColumnFormatOptions>} */
@@ -1807,6 +1807,7 @@ function findItem(channel, args, command) {
     //NOTE: RH location is https://mhhunthelper.agiletravels.com/tracker.json
     let url = 'https://mhhunthelper.agiletravels.com/searchByItem.php?item_type=loot';
     let retStr = `'${args}' not found`;
+    let isDM = ['dm', 'group'].includes(channel.type);
 
     // Deep copy the input args, in case we modify them.
     const orig_args = JSON.parse(JSON.stringify(args));
@@ -1849,7 +1850,7 @@ function findItem(channel, args, command) {
             `result` : `results`} for '${args}'. Here's the top result:`);
 
     matches.forEach((item, i) => {
-        if (i) return;
+        if (i && !isDM) return;
         let id = item.id,
             name = item.value,
             query = url + `&item_id=${id}`;
@@ -1882,8 +1883,7 @@ function findItem(channel, args, command) {
                 // Sort the setups by the drop rate.
                 attractions.sort((a, b) => b.rate - a.rate);
                 // Keep only the top 10 results, unless this is a DM.
-                if (channel.type !== 'dm')
-                    attractions.splice(10);
+                attractions.splice(isDM ? 10 : 100);
 
                 // Column Formatting specification.
                 /** @type {Object <string, ColumnFormatOptions>} */

--- a/MHTimer.js
+++ b/MHTimer.js
@@ -1707,90 +1707,75 @@ function findMouse(channel, args, command) {
     /**
      * Query @devjacksmith's database for information about the valid mouse.
      * @param {boolean} canSpam Whether the long or short response should be sent back.
-     * @param {any} url Endpoint to query (after adding querystring param '&item_id')
      * @param {DatabaseEntity} mouse The valid mouse to query for
+     * @param {Object <string, string>} opts Additional querystring parameters for the request, like 'timefilter'
      * @returns {Promise<string>} The result of the lookup.
      */
-    function _getQueryResult(canSpam, url, mouse) {
-        // TODO: fetch each value once, cache, and serve cached to the user(s).
-        let id = mouse.id,
-            name = mouse.value,
-            query = url + `&item_id=${id}`;
-        return new Promise((resolve, reject) => {
-            request({
-                url: query,
-                json: true
-            }, (error, response, body) => {
-                const attractions = [];
-                if (!error && response.statusCode === 200 && Array.isArray(body)) {
-                    // body is an array of objects with: location, stage, total_hunts, rate, cheese
-                    // Sort it by "rate" but only if hunts > 100
-                    body.filter(setup => setup.total_hunts > 99).forEach(setup => {
-                        attractions.push(
-                            {
-                                location: setup.location,
-                                stage: setup.stage ? setup.stage : " N/A ",
-                                total_hunts: integerComma(setup.total_hunts),
-                                rate: setup.rate * 1.0 / 100,
-                                cheese: setup.cheese
-                            });
-                    });
-                } else {
-                    console.log("Mice: Lookup failed for some reason:\n", error, response ? response.toJSON() : "No response", body);
-                    resolve(`Could not process results for '${args}', AKA ${name}`);
-                    return;
-                }
-
-                // If there was a result, create a nice-looking table from the data.
-                let retStr = "";
-                if (attractions.length) {
-                    // Sort that by Attraction Rate, descending.
-                    attractions.sort((a, b) => (b.rate - a.rate));
-                    // Keep only the top 10 results, unless this is a DM.
-                    attractions.splice(!canSpam ? 10 : 100);
-
-                    // Column Formatting specification.
-                    /** @type {Object <string, ColumnFormatOptions>} */
-                    const columnFormatting = {};
-
-                    // Specify the column order.
-                    const order = ["location", "stage", "cheese", "rate", "total_hunts"];
-                    // Inspect the attractions array to determine if we need to include the stage column.
-                    if (attractions.every(row => row.stage === " N/A "))
-                        order.splice(order.indexOf("stage"), 1);
-
-                    // Build the header row.
-                    const labels = { location: "Location", stage: "Stage", total_hunts: "Hunts", rate: "AR", cheese: "Cheese" }
-                    const headers = order.map(key => {
-                        columnFormatting[key] = {
-                            columnWidth: labels[key].length,
-                            alignRight: !isNaN(parseInt(attractions[0][key], 10))
-                        };
-                        return { 'key': key, 'label': labels[key] };
-                    })
-
-                    // Give the numeric column proper formatting.
-                    // TODO: toLocaleString - can it replace integerComma too?
-                    columnFormatting['rate'] = {
-                        alignRight: true,
-                        isFixedWidth: true,
-                        columnWidth: 7,
-                        suffix: "%"
+    function _getQueryResult(canSpam, mouse, opts) {
+        return getQueriedData('mouse', mouse, opts).then(body => {
+            // Querying succeeded. Received a JSON object (either from cache or HTTP lookup).
+            // body is an array of objects with: location, stage, total_hunts, rate, cheese
+            // Sort it by "rate" but only if hunts > 100
+            const attractions = body.filter(setup => setup.total_hunts > 99)
+                .map(setup => {
+                    return {
+                        location: setup.location,
+                        stage: setup.stage ? setup.stage : " N/A ",
+                        total_hunts: integerComma(setup.total_hunts),
+                        rate: setup.rate * 1.0 / 100,
+                        cheese: setup.cheese
                     };
+                });
+            if (!attractions.length)
+                return `${mouse.value} either hasn't been seen enough, or something broke.`;
 
-                    retStr = `${name} (mouse) can be found the following ways:\n\`\`\``;
-                    retStr += prettyPrintArrayAsString(attractions, columnFormatting, headers, "=");
-                    retStr += `\`\`\`\nHTML version at: <https://mhhunthelper.agiletravels.com/?mouse=${id}>`;
-                }
-                else
-                    retStr = `${name} either hasn't been seen enough, or something broke.`;
-                resolve(retStr);
+            // Sort that by Attraction Rate, descending.
+            attractions.sort((a, b) => b.rate - a.rate);
+            // Keep only the top 10 results, unless this is a DM.
+            attractions.splice(!canSpam ? 10 : 100);
+
+            // Column Formatting specification.
+            /** @type {Object <string, ColumnFormatOptions>} */
+            const columnFormatting = {};
+
+            // Specify the column order.
+            const order = ["location", "stage", "cheese", "rate", "total_hunts"];
+            // Inspect the attractions array to determine if we need to include the stage column.
+            if (attractions.every(row => row.stage === " N/A "))
+                order.splice(order.indexOf("stage"), 1);
+
+            // Build the header row.
+            const labels = { location: "Location", stage: "Stage", total_hunts: "Hunts", rate: "AR", cheese: "Cheese" }
+            const headers = order.map(key => {
+                columnFormatting[key] = {
+                    columnWidth: labels[key].length,
+                    alignRight: !isNaN(parseInt(attractions[0][key], 10))
+                };
+                return { 'key': key, 'label': labels[key] };
             });
+
+            // Give the numeric column proper formatting.
+            // TODO: toLocaleString - can it replace integerComma too?
+            columnFormatting['rate'] = {
+                alignRight: true,
+                isFixedWidth: true,
+                columnWidth: 7,
+                suffix: "%"
+            };
+
+            let retStr = `${mouse.value} (mouse) can be found the following ways:\n\`\`\``;
+            retStr += prettyPrintArrayAsString(attractions, columnFormatting, headers, "=");
+            retStr += `\`\`\`\nHTML version at: <https://mhhunthelper.agiletravels.com/?mouse=${mouse.id}>`;
+            return retStr;
+        }, reason => {
+            // Querying failed. Received an error object / string, and possibly a response object.
+            console.log('Mice: Lookup failed for some reason:\n', reason.error, reason.response ? reason.response.toJSON() : "No HTTP response");
+            throw new Error(`Could not process results for '${args}', AKA ${mouse.value}`);
         });
     }
 
     //NOTE: RH location is https://mhhunthelper.agiletravels.com/tracker.json
-    let url = 'https://mhhunthelper.agiletravels.com/searchByItem.php?item_type=mouse';
+    let qsParams = {};
     let isDM = ['dm', 'group'].includes(channel.type);
 
     // Deep copy the input args, in case we modify them.
@@ -1800,7 +1785,7 @@ function findMouse(channel, args, command) {
     let tokens = args.split(/\s+/);
     if (tokens.length > 2) {
         if (tokens[0] === "-e") {
-            url += `&timefilter=${tokens[1]}`;
+            qsParams.timefilter = tokens[1].toString();
             tokens.splice(0, 2);
         }
         args = tokens.join(" ");
@@ -1905,87 +1890,76 @@ function findItem(channel, args, command) {
     /**
      * Query @devjacksmith's database for information about the valid item.
      * @param {boolean} canSpam Whether the long or short response should be sent back.
-     * @param {any} url Endpoint to query (after adding querystring param '&item_id')
      * @param {DatabaseEntity} item The valid item to query for
+     * @param {Object <string, string>} opts Additional querystring parameters for the request, like 'timefilter'
      * @returns {Promise<string>} The result of the lookup.
      */
-    function _getQueryResult(canSpam, url, item) {
-        // TODO: fetch each value once, cache, and serve cached to the user(s).
-        let id = item.id,
-            name = item.value,
-            query = url + `&item_id=${id}`;
-        return new Promise((resolve, reject) => {
-            request({
-                url: query,
-                json: true
-            }, (error, response, body) => {
-                const attractions = [];
-                if (!error && response.statusCode == 200 && Array.isArray(body)) {
-                    // body is an array of objects with: location, stage, total_hunts, rate, cheese
-                    // 2018-06-18 rate -> rate_per_catch; total_hunts -> total_catches
-                    // Sort by "rate" but only if hunts >= 100
-                    body.filter(setup => setup.total_catches > 99).forEach(setup => {
-                        attractions.push(
-                            {
-                                location: setup.location,
-                                stage: setup.stage === null ? " N/A " : setup.stage,
-                                total_hunts: integerComma(setup.total_catches),
-                                rate: setup.rate_per_catch * 1.0 / 1000, // Divide by 1000? should this be 100?
-                                cheese: setup.cheese
-                            });
-                    });
-                } else {
-                    console.log("Loot: Lookup failed for some reason", error, response ? response.toJSON() : "No response", body);
-                    resolve(`Could not process results for '${args}', AKA ${name}`);
-                    return;
-                }
-                let retStr = "";
-                if (attractions.length) {
-                    // Sort the setups by the drop rate.
-                    attractions.sort((a, b) => b.rate - a.rate);
-                    // Keep only the top 10 results, unless this is a DM.
-                    attractions.splice(!canSpam ? 10 : 100);
-
-                    // Column Formatting specification.
-                    /** @type {Object <string, ColumnFormatOptions>} */
-                    const columnFormatting = {};
-
-                    // Specify the column order.
-                    const order = ["location", "stage", "cheese", "rate", "total_hunts"];
-                    // Inspect the setups array to determine if we need to include the stage column.
-                    if (attractions.every(row => row.stage === " N/A "))
-                        order.splice(order.indexOf("stage"), 1);
-
-                    // Build the header row.
-                    const labels = { location: "Location", stage: "Stage", total_hunts: "Catches", rate: "DR", cheese: "Cheese" }
-                    const headers = order.map(key => {
-                        columnFormatting[key] = {
-                            columnWidth: labels[key].length,
-                            alignRight: !isNaN(parseInt(attractions[0][key], 10))
-                        };
-                        return { 'key': key, 'label': labels[key] };
-                    })
-
-                    // Give the numeric column proper formatting.
-                    columnFormatting['rate'] = {
-                        alignRight: true,
-                        isFixedWidth: true,
-                        numDecimals: 3,
-                        columnWidth: 7,
+    function _getQueryResult(canSpam, item, opts) {
+        return getQueriedData('loot', item, opts).then(body => {
+            // Querying succeeded. Received a JSON object (either from cache or HTTP lookup).
+            // body is an array of objects with: location, stage, total_hunts, rate, cheese
+            // 2018-06-18 rate -> rate_per_catch; total_hunts -> total_catches
+            // Sort by "rate" but only if hunts >= 100
+            const attractions = body.filter(setup => setup.total_catches > 99)
+                .map(setup => {
+                    return {
+                        location: setup.location,
+                        stage: setup.stage === null ? " N/A " : setup.stage,
+                        total_hunts: integerComma(setup.total_catches),
+                        rate: setup.rate_per_catch * 1.0 / 1000, // Divide by 1000? should this be 100?
+                        cheese: setup.cheese
                     };
+                });
+            if (!attractions.length)
+                return `${item.value} either hasn't been seen enough, or something broke.`;
 
-                    retStr = `${name} (loot) can be found the following ways:\n\`\`\``;
-                    retStr += prettyPrintArrayAsString(attractions, columnFormatting, headers, "=");
-                    retStr += `\`\`\`\nHTML version at: <https://mhhunthelper.agiletravels.com/loot.php?item=${id}&timefilter=${timefilter ? timefilter : "all"}>`;
-                } else
-                    retStr = `${name} either hasn't been seen enough, or something broke.`;
-                resolve(retStr);
-            });
+            // Sort the setups by the drop rate.
+            attractions.sort((a, b) => b.rate - a.rate);
+            // Keep only the top 10 results, unless this is a DM.
+            attractions.splice(!canSpam ? 10 : 100);
+
+            // Column Formatting specification.
+            /** @type {Object <string, ColumnFormatOptions>} */
+            const columnFormatting = {};
+
+            // Specify the column order.
+            const order = ["location", "stage", "cheese", "rate", "total_hunts"];
+            // Inspect the setups array to determine if we need to include the stage column.
+            if (attractions.every(row => row.stage === " N/A "))
+                order.splice(order.indexOf("stage"), 1);
+
+            // Build the header row.
+            const labels = { location: "Location", stage: "Stage", total_hunts: "Catches", rate: "DR", cheese: "Cheese" }
+            const headers = order.map(key => {
+                columnFormatting[key] = {
+                    columnWidth: labels[key].length,
+                    alignRight: !isNaN(parseInt(attractions[0][key], 10))
+                };
+                return { 'key': key, 'label': labels[key] };
+            })
+
+            // Give the numeric column proper formatting.
+            columnFormatting['rate'] = {
+                alignRight: true,
+                isFixedWidth: true,
+                numDecimals: 3,
+                columnWidth: 7,
+            };
+
+            let retStr = `${item.value} (loot) can be found the following ways:\n\`\`\``;
+            retStr += prettyPrintArrayAsString(attractions, columnFormatting, headers, "=");
+            retStr += `\`\`\`\nHTML version at: <https://mhhunthelper.agiletravels.com/loot.php?item=${item.id}&timefilter=${timefilter ? timefilter : "all"}>`;
+            return retStr;
+        }, reason => {
+            // Querying failed. Received an error object / string, and possibly a response object.
+            console.log('Loot: Lookup failed for some reason:\n', reason.error, reason.response ? reason.response.toJSON() : "No HTTP response");
+            throw new Error(`Could not process results for '${args}', AKA ${item.value}`);
         });
     }
 
+
     //NOTE: RH location is https://mhhunthelper.agiletravels.com/tracker.json
-    let url = 'https://mhhunthelper.agiletravels.com/searchByItem.php?item_type=loot';
+    let qsParams = {};
     let isDM = ['dm', 'group'].includes(channel.type);
 
     // Deep copy the input args, in case we modify them.
@@ -2004,7 +1978,7 @@ function findItem(channel, args, command) {
                     break;
             }
 
-            url += `&timefilter=${tokens[1]}`;
+            qsParams.timefilter = tokens[1];
             timefilter = tokens[1];
             tokens.splice(0, 2);
         }

--- a/MHTimer.js
+++ b/MHTimer.js
@@ -1977,49 +1977,40 @@ function findItem(channel, args, command) {
  */
 function sendInteractiveSearchResult(searchResults, channel, dataCallback, isDM, qsParams, searchInput) {
     const matches = searchResults.map((sr, i) => ({ emojiId: emojis[i].id, match: sr }));
-    if (matches.length === 1) {
-        // Send the single result directly.
-        dataCallback(isDM, matches[0].match, qsParams).then(
-            result => channel.send(`I found one good result for '${searchInput}':\n${result}`, { split: { prepend: '```', append: '```' } }),
-            result => channel.send(result)
-        ).catch(err => console.log(err));
-    }
-    else {
-        // Create reactions, and when the user uses the corresponding reaction, PM the data.
-        let retStr = matches.reduce((acc, entity, i) => {
-            let row = `\n\t${emojis[i].text}:\t${entity.match.value}`;
-            return acc + row;
-        }, `I found ${matches.length} good results for '${searchInput}':`);
-        retStr += `\n\nFor any reaction you select, I'll ${isDM ? 'send' : 'PM'} you that information.`;
-        let sent = channel.send(retStr);
-        // To ensure a sensible order of emojis, we have to await the previous react's resolution.
-        sent.then(async (msg) => {
-            /** @type MessageReaction[] */
-            let mrxns = [];
-            for (let m of matches)
-                mrxns.push(await msg.react(m.emojiId).catch(err => console.log(err)));
-            return mrxns;
-        }).then(msgRxns => {
-            // Set a 5-minute listener on the message for these reactions.
-            let msg = msgRxns[0].message,
-                allowed = msgRxns.map(mr => mr.emoji.name),
-                filter = (reaction, user) => allowed.includes(reaction.emoji.name) && !user.bot,
-                rc = msg.createReactionCollector(filter, { time: 5 * 60 * 1000 });
-            rc.on('collect', mr => {
-                // Fetch the response and send it to the user.
-                let match = matches.filter(m => m.emojiId === mr.emoji.identifier)[0];
-                if (match) dataCallback(true, match.match, qsParams).then(
-                    result => mr.users.last().send(result, { split: { prepend: '```', append: '```' } }),
-                    result => mr.users.last().send(result)
-                ).catch(err => console.log(err));
-            }).on('end', () => rc.message.clearReactions().catch(() => rc.message.delete()));
-        }).catch(err => console.log('Reactions: error setting reactions:\n', err));
-        // Always send one result to the channel.
-        sent.then(() => dataCallback(isDM, matches[0].match, qsParams).then(
-            result => channel.send(result, { split: { prepend: '```', append: '```' } }),
-            result => channel.send(result))
-        ).catch(err => console.log(err));
-    }
+    // Create reactions, and when the user uses the corresponding reaction, PM the data.
+    let retStr = matches.reduce((acc, entity, i) => {
+        let row = `\n\t${emojis[i].text}:\t${entity.match.value}`;
+        return acc + row;
+    }, `I found ${matches.length === 1 ? `a single result` : `${matches.length} good results`} for '${searchInput}':`);
+    retStr += `\n\nFor any reaction you select, I'll ${isDM ? 'send' : 'PM'} you that information.`;
+    let sent = channel.send(retStr);
+    // To ensure a sensible order of emojis, we have to await the previous react's resolution.
+    sent.then(async (msg) => {
+        /** @type MessageReaction[] */
+        let mrxns = [];
+        for (let m of matches)
+            mrxns.push(await msg.react(m.emojiId).catch(err => console.log(err)));
+        return mrxns;
+    }).then(msgRxns => {
+        // Set a 5-minute listener on the message for these reactions.
+        let msg = msgRxns[0].message,
+            allowed = msgRxns.map(mr => mr.emoji.name),
+            filter = (reaction, user) => allowed.includes(reaction.emoji.name) && !user.bot,
+            rc = msg.createReactionCollector(filter, { time: 5 * 60 * 1000 });
+        rc.on('collect', mr => {
+            // Fetch the response and send it to the user.
+            let match = matches.filter(m => m.emojiId === mr.emoji.identifier)[0];
+            if (match) dataCallback(true, match.match, qsParams).then(
+                result => mr.users.last().send(result, { split: { prepend: '```', append: '```' } }),
+                result => mr.users.last().send(result)
+            ).catch(err => console.log(err));
+        }).on('end', () => rc.message.clearReactions().catch(() => rc.message.delete()));
+    }).catch(err => console.log('Reactions: error setting reactions:\n', err));
+    // Always send one result to the channel.
+    sent.then(() => dataCallback(isDM, matches[0].match, qsParams).then(
+        result => channel.send(result, { split: { prepend: '```', append: '```' } }),
+        result => channel.send(result))
+    ).catch(err => console.log(err));
 }
 
 /**

--- a/MHTimer.js
+++ b/MHTimer.js
@@ -1600,6 +1600,14 @@ function getHelpMessage(tokens) {
         return `I don't know that one, but I do know ${keywords}.`;
 }
 
+
+/**
+ * @typedef {Object} DatabaseEntity
+ * @property {string} id The ID of the entity
+ * @property {string} value The entity's proper name
+ * @property {string} lowerValue A lowercased version of the entity's name
+ */
+
 /**
  * Initialize (or refresh) the known mice lists from @devjacksmith's tools.
  */
@@ -1907,6 +1915,27 @@ function findItem(channel, args, command) {
         getMouseList();
     }
 }
+
+/**
+ * Return a sorted list of approximate matches to the given input and container
+ *
+ * @param {string} input The text to match against
+ * @param {DatabaseEntity[]} values The known values.
+ * returns {number[][]} Up to 10 indices and their search score.
+ */
+function getSearchedEntity(input, values) {
+    if (!input.length || !Array.isArray(values) || !values.length)
+        return [];
+
+    const matches = values.filter(v => v.lowerValue.includes(input)).map(v => {
+        return {entity: v, score: v.lowerValue.indexOf(input)};
+    });
+    matches.sort((a, b) => a.score - b.score).splice(5);
+    console.log(`From input '${input}' found ${matches.length} matches`, matches);
+    return matches.map(m => m.entity);
+}
+
+
 
 /**
  * Interrogate the local 'hunters' data object to find self-registered hunters that match the requested

--- a/MHTimer.js
+++ b/MHTimer.js
@@ -1682,9 +1682,11 @@ function findMouse(channel, args, command) {
         }
     }
     else
-        channel.send(`I found ${matches.length} good ${matches.length === 1 ? `result` : `results`} for '${args}'`);
+        channel.send(`I found ${matches.length} good ${matches.length === 1 ?
+            `result` : `results`} for '${args}'. Here's the top result:`);
 
-    matches.forEach(mouse => {
+    matches.forEach((mouse, i) => {
+        if (i) return;
         let id = mouse.id,
             name = mouse.value,
             query = url + `&item_id=${id}`;
@@ -1843,9 +1845,11 @@ function findItem(channel, args, command) {
         }
     }
     else
-        channel.send(`I found ${matches.length} good ${matches.length === 1 ? `result` : `results`} for '${args}'`);
+        channel.send(`I found ${matches.length} good ${matches.length === 1 ?
+            `result` : `results`} for '${args}'. Here's the top result:`);
 
-    matches.forEach(item => {
+    matches.forEach((item, i) => {
+        if (i) return;
         let id = item.id,
             name = item.value,
             query = url + `&item_id=${id}`;

--- a/MHTimer.js
+++ b/MHTimer.js
@@ -6,7 +6,7 @@ const { DateTime, Duration, Interval } = require('luxon');
 const Discord = require('discord.js');
 
 // Import type-hinting definitions
-const { Client, Guild, Message, RichEmbed, TextChannel, User } = require('discord.js');
+const { Client, Guild, Message, MessageReaction, RichEmbed, TextChannel, User } = require('discord.js');
 
 const Timer = require('./timerClass.js');
 // Access local URIs, like files.
@@ -54,6 +54,17 @@ const last_timestamps = {
 const dataTimers = {};
 /** @type {Map <string, {active: boolean, channels: TextChannel[], inactiveChannels: TextChannel[]}>} */
 const timer_config = new Map();
+const emojis = [
+    { id: "1%E2%83%A3", text: ':one:' },
+    { id: "2%E2%83%A3", text: ':two:' },
+    { id: "3%E2%83%A3", text: ':three:' },
+    { id: "4%E2%83%A3", text: ':four:' },
+    { id: "5%E2%83%A3", text: ':five:' },
+    { id: "6%E2%83%A3", text: ':six:' },
+    { id: "7%E2%83%A3", text: ':seven:' },
+    { id: "8%E2%83%A3", text: ':eight:' },
+    { id: "9%E2%83%A3", text: ':nine:' },
+    { id: "%F0%9F%94%9F", text: ':keycap_ten:' }];
 
 //https://stackoverflow.com/questions/12008120/console-log-timestamps-in-chrome
 console.logCopy = console.log.bind(console);
@@ -1643,7 +1654,7 @@ function getMouseList() {
 }
 
 /**
- * Query @devjacksmith's database for information about the desired mouse.
+ * Check the input args for a known mouse that can be looked up.
  * If no result is found, retries with an item search.
  *
  * @param {TextChannel} channel the channel on which to respond.
@@ -1796,7 +1807,7 @@ function getItemList() {
 }
 
 /**
- * Query @devjacksmith's database for information about the desired item.
+ * Check the input args for a known item that can be looked up.
  * If no result is found, retries with a mouse search.
  *
  * @param {TextChannel} channel the channel on which to respond.
@@ -1942,8 +1953,8 @@ function getSearchedEntity(input, values) {
         // Sort lexicographically if the scores are equal.
         return r ? r : a.entity.value.localeCompare(b.entity.value, { sensitivity: "base" });
     })
-    // Keep only the top 5 results.
-    matches.splice(5);
+    // Keep only the top 10 results.
+    matches.splice(10);
     return matches.map(m => m.entity);
 }
 


### PR DESCRIPTION
Bias the result to those entities that have the searched query occurring earlier in the entity name, e.g. Cavalier before Sand Cavalry for 'caval'.

 - Still prints the top result.
 - Adds reactions for the top 10 results
   - If clicked, PMs the user the associated detailed result
 - In PM / Group DM, the search result responses will be 100 entries long at most, per #46 

Nicknames convert the input to the full entity value, so the nickname will have only 1 result unless that true name is wholly contained in another entity of the same type (e.g. "sleeves" -> "Acolyte" -> matches both "Acolyte" and "Absolute Acolyte".