### PR TITLE
Remove "request" and update RH logic, startup / shutdown sequence

### DIFF
--- a/MHTimer.js
+++ b/MHTimer.js
@@ -12,7 +12,6 @@ const Timer = require('./timerClass.js');
 // Access local URIs, like files.
 const fs = require('fs');
 // Access external URIs, like @devjacksmith 's tools.
-const request = require('request');
 const fetch = require('node-fetch');
 const { URLSearchParams } = require('url');
 // We need more robust CSV handling
@@ -113,10 +112,10 @@ console.log = function()
     }
 };
 
-process.on('SIGINT', () => {
+process.once('SIGINT', () => {
     client.destroy();
 });
-process.on('SIGTERM', () => {
+process.once('SIGTERM', () => {
     client.destroy();
 });
 
@@ -290,7 +289,7 @@ function Main() {
         })
         // Finally, log in now that we have loaded all data from disk,
         // requested data from remote sources, and configured the bot.
-        .then(didConfig => client.login(settings.token))
+        .then(() => client.login(settings.token))
         .catch(err => {
             console.log('Unhandled startup error, shutting down:', err);
             client.destroy()
@@ -306,11 +305,11 @@ catch(error) {
 
 function quit() {
     return doSaveAll()
-        .then(didSave => {
-            console.log(`Shutdown: data saves completed`);
-            return didSave;
-        }, err => console.log(`Shutdown: error while saving:\n`, err))
-        .then(didSave => { console.log(`Shutdown: destroying client`); return client.destroy(); })
+        .then(
+            () => console.log(`Shutdown: data saves completed`),
+            (err) => console.log(`Shutdown: error while saving:\n`, err)
+        )
+        .then(() => { console.log(`Shutdown: destroying client`); return client.destroy(); })
         .then(() => {
             console.log(`Shutdown: deactivating data refreshes`);
             for (let timer of Object.values(dataTimers))
@@ -320,8 +319,11 @@ function quit() {
                 timer.stopInterval();
                 timer.stopTimeout();
             }
+            if (relic_hunter.timeout) {
+                clearTimeout(relic_hunter.timeout);
+            }
         })
-        .then(result => process.exitCode = 1)
+        .then(() => process.exitCode = 1)
         .catch(err => {
             console.log(`Shutdown: unhandled error:\n`, err, `\nImmediately exiting.`);
             process.exit();
@@ -398,7 +400,7 @@ function loadSettings(path = main_settings_filename) {
             settings.timedAnnouncementChannels = settings.timedAnnouncementChannels.split(",").map(s => s.trim());
         settings.timedAnnouncementChannels = new Set(settings.timedAnnouncementChannels);
 
-        settings.relic_hunter_webhook = settings.relic_hunter_webhook ? settings.relic_hunter_webhook : "283571156236107777";
+        settings.relic_hunter_webhook = settings.relic_hunter_webhook || "283571156236107777";
 
         settings.botPrefix = settings.botPrefix ? settings.botPrefix.trim() : '-mh';
 
@@ -1326,6 +1328,8 @@ function doAnnounce(timer) {
  * @param {Timer} timer The activated timer.
  */
 function doRemind(timer) {
+    if (!timer) return;
+
     // Cache these values.
     const area = timer.getArea(),
         sub = timer.getSubArea();
@@ -1932,7 +1936,7 @@ function findMouse(channel, args, command) {
 
     // Special case of the relic hunter RGW
     if (args.toLowerCase() === "relic hunter") {
-        findRH(channel).then();
+        findRH(channel);
         return;
     }
 
@@ -2469,26 +2473,26 @@ function integerComma(number) {
 }
 
 /**
-
  * Reset the Relic Hunter location so reminders know to update people
  */
 function resetRH() {
-    console.log(`Relic hunter location was ${relic_hunter.location} from ${relic_hunter.source}`);
+    console.log(`Relic hunter: resetting location to "unknown", was ${relic_hunter.source}: ${relic_hunter.location}`);
     relic_hunter.location = 'unknown';
     relic_hunter.source = 'reset';
+    relic_hunter.last_seen = DateTime.fromMillis(0);
+    // Schedule the next reset.
     rescheduleResetRH();
-    console.log('Relic hunter location was reset');
 }
 
 /**
  * Continue resetting Relic Hunter location
  */
-
 function rescheduleResetRH() {
     if (relic_hunter.timeout)
         clearTimeout(relic_hunter.timeout);
 
-    relic_hunter.timeout = setTimeout(resetRH, Interval.fromDateTimes(DateTime.utc(),DateTime.utc().endOf('day')).length('milliseconds') );
+    const now = DateTime.utc();
+    relic_hunter.timeout = setTimeout(resetRH, Interval.fromDateTimes(now, now.endOf('day')).length('milliseconds'));
 }
 
 /**
@@ -2497,7 +2501,7 @@ function rescheduleResetRH() {
 function remindRH(new_location) {
     //Logic to look for people with the reminder goes here
     if (new_location != 'unknown') {
-        console.log(`Reminding about relic hunter in ${new_location}`);
+        console.log(`Relic Hunter: Sending reminders for ${new_location}`);
         doRemind(timers_list.find(t => t.getArea() === "relic_hunter"));
     }
 }
@@ -2526,89 +2530,59 @@ function updRH(message) {
  * Especially at startup, find the relic hunter's location
  * TODO: This might replace the reset function
  */
-
 async function getRHLocation() {
-    console.log(`Relic hunter was in ${relic_hunter.location} according to ${relic_hunter.source}`);
-    const newLocations = await Promise.all([
+    console.log(`Relic Hunter: Was in ${relic_hunter.location} according to ${relic_hunter.source}`);
+    const [dbg, mhct] = await Promise.all([
         DBGamesRHLookup(),
         MHCTRHLookup()
     ]);
-    // Precedence goes to MHCT because it would have seen RH
-    let newLocation = newLocations.find(t => t && t.source === 'MHCT' && t.location !== 'unknown');
-    if (newLocation && newLocation.location) {
-        relic_hunter.location = newLocation.location;
-        relic_hunter.source = 'MHCT';
+    // Trust MHCT more, since it would actually observe an RH appearance, rather than decode a hint.
+    if (mhct.location !== 'unknown') {
+        Object.assign(relic_hunter, mhct);
+    } else if (dbg.location !== 'unknown') {
+        Object.assign(relic_hunter, dbg);
     } else {
-        newLocation = newLocations.find(t => t && t.source === 'DBGames');
-        if (newLocation && newLocation.location) {
-            relic_hunter.location = newLocation.location;
-            relic_hunter.source = 'DBGames';
-        }
+        // Both sources returned unknown.
+        resetRH();
     }
-    console.log(`Relic hunter is in ${relic_hunter.location} according to ${relic_hunter.source}`);
+    console.log(`Relic Hunter: location set to "${relic_hunter.location}" with source "${relic_hunter.source}"`);
 }
 
 /**
  * Looks up Relic Hunter Location from DBGames via Google Sheets
- * @returns {Promise<unknown>}
- * @constructor
+ * @returns {Promise<{ location: string, source: 'DBGames' }>}
  */
 function DBGamesRHLookup() {
-    let new_location = 'unknown';
-    return new Promise(function(resolve){
-        let req = request({
-                uri: 'https://docs.google.com/spreadsheets/d/e/2PACX-1vSsqAjocBWcN5dDLXuOBfnBhyrTaO7ZeIEAFlDnQ4r6zqcvtuLKMDBQCh5I8-3M9irS4-17OPfvgKtY/pub?gid=1975888453&single=true&output=csv'
-            }, (error, response, body) => {
-                if (!error && response.statusCode === 200 && body) {
-                    console.log(`Relic hunter location updated from ${relic_hunter.location} to ${body}`);
-                    resolve({
-                        source: 'DBGames',
-                        location: body,
-                        last_seen: 0
-                    });
-                } else {
-                    console.log(`RelicHunter query failed:`, error, response, body);
-                    resolve({
-                        source: 'broken',
-                        location: 'unknown',
-                        last_seen: 0
-                    });
-                }
-            });
-    });
-
+    return fetch('https://docs.google.com/spreadsheets/d/e/2PACX-1vSsqAjocBWcN5dDLXuOBfnBhyrTaO7ZeIEAFlDnQ4r6zqcvtuLKMDBQCh5I8-3M9irS4-17OPfvgKtY/pub?gid=1975888453&single=true&output=csv')
+        .then(async (response) => {
+            if (!response.ok) throw `HTTP ${response.status}`;
+            const location = await response.text();
+            console.log('Relic Hunter: DBGames query OK, reported location:', location);
+            return { source: 'DBGames', location, last_seen: DateTime.utc().startOf('day') };
+        })
+        .catch((err) => {
+            console.log(`Relic Hunter: DBGames query failed:`, err);
+            return { source: 'DBGames', location: 'unknown' };
+        });
 }
 
 /**
  * Looks up the relic hunter location from MHCT
+ * @returns {Promise<{ location: string, source: 'MHCT' }>}
  */
 function MHCTRHLookup() {
-    if (relic_hunter.source === 'MHCT' && relic_hunter.location !== 'unknown') {
-        return;
-    }
-    return new Promise(function(resolve){
-        let req = request({
-            uri: 'https://mhhunthelper.agiletravels.com/tracker.json',
-            json: true
-        }, (error, response, body) => {
-            if (!error && response.statusCode === 200) {
-                resolve({
-                        source: 'MHCT',
-                        location: decode(body["rh"]["location"]),
-                        last_seen: decode(body["rh"]["last_seen"])
-                    }
-                );
-            } else {
-                console.log(`RelicHunter query failed:`, error, response, body);
-                resolve({
-                    source: 'broken',
-                    location: 'unknown',
-                    last_seen: 0
-                    }
-                );
-            }
+    return fetch('https://mhhunthelper.agiletravels.com/tracker.json')
+        .then(async (response) => {
+            if (!response.ok) throw `HTTP ${response.status}`;
+            const { rh } = await response.json();
+            console.log('Relic Hunter: MHCT query OK, reported location:', rh.location);
+            // TODO: what's the format of rh.last_seen? when "unknown", has value 0. Assuming milliseconds UTC
+            return { source: 'MHCT', last_seen: DateTime.fromMillis(rh.last_seen), location: rh.location };
+        })
+        .catch((err) => {
+            console.log(`Relic Hunter: MHCT query failed:`, err);
+            return { source: 'MHCT', location: 'unknown' };
         });
-    });
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,100 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "ajv": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-      "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
-      "requires": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      }
-    },
-    "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-    },
-    "aws4": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      },
-      "dependencies": {
-        "tweetnacl": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-        }
-      }
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
     "csv-parse": {
       "version": "4.8.8",
       "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.8.8.tgz",
       "integrity": "sha512-Kv3Ilz2GV58dOoHBXRCTF8ijxlLjl80bG3d67XPI6DNqffb3AnbPbKr/WvCUMJq5V0AZYi6sukOaOQAVpfuVbg=="
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "discord.js": {
       "version": "11.6.2",
@@ -111,20 +26,6 @@
         "ws": "^6.0.0"
       }
     },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
     "extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
@@ -133,113 +34,10 @@
         "is-extendable": "^0.1.0"
       }
     },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-    },
-    "fast-deep-equal": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
-    },
-    "fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
-    },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-    },
-    "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      }
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-    },
-    "har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-      "requires": {
-        "ajv": "^6.5.5",
-        "har-schema": "^2.0.0"
-      }
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      }
-    },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
-    },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-    },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
-    "json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
     },
     "long": {
       "version": "4.0.0",
@@ -251,135 +49,20 @@
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.22.0.tgz",
       "integrity": "sha512-3sLvlfbFo+AxVEY3IqxymbumtnlgBwjDExxK60W3d+trrUzErNAz/PfvPT+mva+vEUrdIodeCOs7fB6zHtRSrw=="
     },
-    "mime-db": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
-    },
-    "mime-types": {
-      "version": "2.1.26",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
-      "requires": {
-        "mime-db": "1.43.0"
-      }
-    },
     "node-fetch": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
-    },
-    "oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-    },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "prism-media": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-0.0.4.tgz",
       "integrity": "sha512-dG2w7WtovUa4SiYTdWn9H8Bd4JNdei2djtkP/Bk9fXq81j5Q15ZPHYSwhUVvBRbp5zMkGtu0Yk62HuMcly0pRw=="
     },
-    "psl": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
-      "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ=="
-    },
-    "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-    },
-    "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
-    },
-    "request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      }
-    },
-    "safe-buffer": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
-    },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
     "snekfetch": {
       "version": "3.6.4",
       "resolved": "https://registry.npmjs.org/snekfetch/-/snekfetch-3.6.4.tgz",
       "integrity": "sha512-NjxjITIj04Ffqid5lqr7XdgwM7X61c/Dns073Ly170bPQHLm6jkmelye/eglS++1nfTWktpP6Y2bFXjdPlQqdw=="
-    },
-    "sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "dependencies": {
-        "tweetnacl": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-        }
-      }
-    },
-    "tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "requires": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      }
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
     },
     "tweetnacl": {
       "version": "1.0.3",
@@ -392,29 +75,6 @@
       "integrity": "sha512-O0+af1Gs50lyH1nUu3ZyYS1cRh01Q/kUKatTOkSs7jukXE6/NebucDVxyiDsA9AQ4JC1V1jUH9EO8JX2nMDgGQ==",
       "requires": {
         "extend-shallow": "^2.0.1"
-      }
-    },
-    "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "requires": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
       }
     },
     "ws": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "discord.js": "^11.6.2",
     "luxon": "^1.22.0",
     "node-fetch": "^2.6.0",
-    "request": "^2.88.2",
     "unescape": "^1.0.1"
   }
 }


### PR DESCRIPTION
 - Removes the request package
 - We might be able to remove the `unescape` package too, as I don't know that the MHCT endpoint requires we call `decode` on its output.
 - update the remote data methods to return a promise, and then require these operations to have completed prior to bot log-in
 - add a missing `clearTimeout` call for the relic_hunter's timeout, to allow graceful shutdown
 - switch the SIGTERM / SIGINT handlers from "on" to "once", so that SIGINT can be used again to force a shutdown
 - moved the initial `rescheduleResetRH` out of a function where it wouldn't get called when no timers are configured.
 - Made the `doRemind` method robust to a bad timer input (e.g. in case no RH timer is defined)

TODO: 
 - [ ] verify webhook message parsing still works
 - [ ] verify we can parse MHCT endpoints without the `decode` call
 - [ ] verify format of MHCT endpoint's `last_seen` property