### PR TITLE
fix(splitString): Add splitString tests and correct some behaviors

### DIFF
--- a/src/modules/format-utils.js
+++ b/src/modules/format-utils.js
@@ -162,6 +162,9 @@ function prettyPrintArrayAsString(body, columnFormat, headers, headerUnderline) 
  */
 function splitString(input) {
     const tokens = [];
+    if (!input) {
+        return tokens;
+    }
     const splitRegexp = /[^\s"]+|"([^"]*)"/gi;
 
     let match = '';

--- a/src/modules/format-utils.js
+++ b/src/modules/format-utils.js
@@ -165,7 +165,7 @@ function splitString(input) {
     if (!input) {
         return tokens;
     }
-    const splitRegexp = /[^\s"]+|"([^"]*)"/gi;
+    const splitRegexp = /[^\s"]+|"([^"]+)"/gi;
 
     let match = '';
     do {

--- a/tests/modules/format-utils.js
+++ b/tests/modules/format-utils.js
@@ -6,7 +6,7 @@ const test = require('tape');
 const {
     oxfordStringifyValues,
     // prettyPrintArrayAsString,
-    // splitString,
+    splitString,
     // timeLeft,
 } = require('../../src/modules/format-utils');
 
@@ -89,5 +89,102 @@ test('oxfordStringifyValues', suite => {
             ['hello', 'world'],
         ]);
         t.deepEqual(oxfordStringifyValues(map), 'earth and world', 'should use map\'s values');
+    });
+});
+test('splitString', suite => {
+    suite.test('given one token - returns array of token as string', t => {
+        const inputs = [
+            { input: 1, expected: ['1'] },
+            { input: '1', expected: ['1'] },
+            { input: 'one', expected: ['one'] },
+            { input: true, expected: ['true'] },
+            { input: String(true), expected: ['true'] },
+            { input: new String(true), expected: ['true'] },
+        ];
+        t.plan(inputs.length);
+        inputs.forEach(({ input, expected }) => t.deepEqual(splitString(input), expected));
+    });
+    suite.test('given "empty" input - returns empty array', t => {
+        const inputs = [
+            { input: '', msg: 'empty string' },
+            { input: undefined, msg: 'undefined' },
+            { input: '""', msg: 'matched empty double quotes' },
+            { input: '"', msg: 'unmatched double quote' },
+            { input: ' ', msg: 'space' },
+            { input: '\t', msg: 'tab' },
+            { input: '\n', msg: 'newline' },
+            { input: `
+`, msg: 'embedded newline' },
+            { input: [], msg: 'array' },
+        ];
+        t.plan(inputs.length);
+        inputs.forEach(({ input, msg }) => t.deepEqual(splitString(input), [], `when given ${msg}`));
+    });
+    suite.test('given multiple tokens - returns array of tokens as strings', t => {
+        const inputs = [
+            { input: 'hello world', expected: ['hello', 'world'], msg: '2 words' },
+            { input: '1 2', expected: ['1', '2'], msg: '2 numbers' },
+            { input: 'hello world MH', expected: ['hello', 'world', 'MH'], msg: '3 words' },
+            { input: '"hello world MH"', expected: ['hello world MH'], msg: 'double-quoted phrase' },
+            { input: '"hello world" MH', expected: ['hello world', 'MH'], msg: 'double-quoted phrase + add\'l word' },
+            { input: '"hello" "world" "MH"', expected: ['hello', 'world', 'MH'], msg: 'individually double-quoted words' },
+        ];
+        t.plan(inputs.length);
+        inputs.forEach(({ input, expected, msg }) => t.deepEqual(
+            splitString(input), expected, `when given ${msg}`,
+        ));
+    });
+    suite.test('quoting behavior', subsuite => {
+        subsuite.test('given matched double-quotes - token is between quotes', t => {
+            const inputs = [
+                { input: '"hi"', expected: ['hi'], msg: 'word' },
+                { input: '"hello world"', expected: ['hello world'], msg: 'phrase' },
+                { input: '", ! ? . "', expected: [', ! ? . '], msg: 'punctuation characters' },
+                { input: '""', expected: [], msg: 'nullstring' },
+            ];
+            t.plan(inputs.length);
+            inputs.forEach(({ input, expected, msg }) => t.deepEqual(
+                splitString(input), expected, `when wrapping ${msg}`,
+            ));
+        });
+        subsuite.test('given unmatched double-quotes - strips quotes', t => {
+            const inputs = [
+                { input: '"hi', expected: ['hi'], msg: 'leads word' },
+                { input: 'hi"', expected: ['hi'], msg: 'trails word' },
+                { input: '"hi there', expected: ['hi', 'there'], msg: 'leads phrase' },
+                { input: 'hi there"', expected: ['hi', 'there'], msg: 'trails phrase' },
+            ];
+            t.plan(inputs.length);
+            inputs.forEach(({ input, expected, msg }) => t.deepEqual(
+                splitString(input), expected, `when quote ${msg}`,
+            ));
+        });
+        subsuite.test('given double-quotes within words - treated as token separators', t => {
+            const inputs = [
+                { input: 'super"typo', expected: ['super', 'typo'] },
+                { input: 'hi"there"friend', expected: ['hi', 'there', 'friend'] },
+                { input: '"hi"there', expected: ['hi', 'there'] },
+                { input: 'hi"there"', expected: ['hi', 'there'] },
+            ];
+            t.plan(inputs.length);
+            inputs.forEach(({ input, expected }) => t.deepEqual(
+                splitString(input), expected,
+            ));
+        });
+        subsuite.test('given single-quotes - treats as normal character', t => {
+            const inputs = [
+                { input: '\'hi\'', expected: ['\'hi\''], msg: 'wrapping word' },
+                { input: '\'hello world\'', expected: ['\'hello', 'world\''], msg: 'wrapping phrase' },
+                { input: '\', ! ? . \'', expected: ['\',',  '!',  '?', '.', '\''], msg: 'wrapping punctuation characters' },
+                { input: '\'\'', expected: ['\'\''], msg: 'wrapping nullstring' },
+                { input: 'she\'s', expected: ['she\'s'], msg: 'used as apostrophe' },
+                { input: '\'this', expected: ['\'this'], msg: 'leading & unmatched' },
+                { input: 'that\'', expected: ['that\''], msg: 'trailing & unmatched' },
+            ];
+            t.plan(inputs.length);
+            inputs.forEach(({ input, expected, msg }) => t.deepEqual(
+                splitString(input), expected, `when ${msg}`,
+            ));
+        });
     });
 });


### PR DESCRIPTION
Behavior changes

 - when argument to `splitString` is `undefined`, returns an empty array of tokens rather than the token `'undefined'`
 - when argument to `splitString` contains adjacent double-quotes, no longer includes `""` as a token
   - e.g. `remind ""` used to yield `['remind', '""']` and now yields `['remind']`