### PR TITLE
test(iam): Add tests for IAM, hunter-registry

### DIFF
--- a/tests/commands/iam.js
+++ b/tests/commands/iam.js
@@ -1,0 +1,68 @@
+const test = require('tape');
+const sinon = require('sinon');
+
+// Stub Logger methods to minimize crosstalk.
+const { stubLogger, restoreLogger } = require('../helpers/logging');
+// Stub hunter registry methods.
+const { stubHunterRegistry, restoreHunterRegistry } = require('../helpers/hunters');
+// We need a decently realistic Message stub
+const mockMessage = require('../helpers/mock-message');
+
+// Declaration of what we're testing.
+/** @type {{ execute: (Message, tokens: string[] ) => Promise<import('../../src/interfaces/command-result')>}} */
+let IAM;
+
+test('commands - IAM', suite => {
+    let logStubs;
+    let hunterStubs;
+    suite.test('Test Suite Setup', t => {
+        logStubs = stubLogger();
+        hunterStubs = stubHunterRegistry();
+
+        // Now that we have stubs active, we can require the test subject.
+        IAM = require('../../src/commands/iam');
+        t.end();
+    });
+
+    suite.test('when channel#send fails - logs error', async t => {
+        t.plan(3);
+        const messageStub = mockMessage({ sendStub: sinon.stub().rejects(Error('oops!')) });
+        await IAM.execute(messageStub, []);
+        t.strictEqual(logStubs.error.callCount, 1, 'should log error');
+        const [description, err] = logStubs.error.getCall(0).args;
+        t.match(description, /failed to send/, 'should indicate error source');
+        t.match(err.message, /oops!/, 'should log error from Message#react');
+
+        sinon.reset();
+    });
+    suite.test('when channel#send fails - flags bot error', async t => {
+        t.plan(1);
+        const messageStub = mockMessage({ sendStub: sinon.stub().rejects(Error('oops!')) });
+        const result = await IAM.execute(messageStub, []);
+        t.true(result.botError, 'should indicate bot error');
+
+        sinon.reset();
+    });
+    suite.test('when called with exactly "not" - calls unsetHunterID', async t => {
+        t.plan(1);
+        const messageStub = mockMessage();
+        await IAM.execute(messageStub, ['not']);
+        t.strictEqual(hunterStubs.unsetHunterID.callCount, 1, 'should call unsetHunterID');
+
+        sinon.reset();
+    });
+    suite.test('when first token is "not" - when multiple args - does nothing', async t => {
+        t.plan(Object.values(hunterStubs).length);
+        const messageStub = mockMessage();
+        await IAM.execute(messageStub, ['not', 'cool']);
+        Object.entries(hunterStubs).forEach(([name, stub]) => t.strictEqual(stub.callCount, 0, `should not call ${name}`));
+
+        sinon.reset();
+    });
+
+    suite.test('Restore Loggers', t => {
+        restoreHunterRegistry(hunterStubs);
+        restoreLogger(logStubs);
+        t.end();
+    });
+});

--- a/tests/helpers/hunters.js
+++ b/tests/helpers/hunters.js
@@ -1,0 +1,18 @@
+// Provide an easy way to intercept calls to the hunter registry commands
+const sinon = require('sinon');
+const hunters = require('../../src/modules/hunter-registry');
+
+const stubHunterRegistry = () => {
+    return {
+        setHunterID: sinon.stub(hunters, 'setHunterID'),
+        unsetHunterID: sinon.stub(hunters, 'unsetHunterID'),
+        setHunterProperty: sinon.stub(hunters, 'setHunterProperty'),
+    };
+};
+
+const restoreHunterRegistry = ({ ...stubs }) => {
+    Object.values(stubs).forEach(stub => stub.restore());
+};
+
+exports.stubHunterRegistry = stubHunterRegistry;
+exports.restoreHunterRegistry = restoreHunterRegistry;

--- a/tests/helpers/logging.js
+++ b/tests/helpers/logging.js
@@ -1,0 +1,16 @@
+const sinon = require('sinon');
+const Logger = require('../../src/modules/logger');
+
+const stubLogger = () => {
+    return {
+        log: sinon.stub(Logger, 'log'),
+        warn: sinon.stub(Logger, 'warn'),
+        error: sinon.stub(Logger, 'error'),
+    };
+};
+const restoreLogger = ({ ...stubs }) => {
+    Object.values(stubs).forEach(stub => stub.restore());
+};
+
+exports.stubLogger = stubLogger;
+exports.restoreLogger = restoreLogger;

--- a/tests/helpers/logging.js
+++ b/tests/helpers/logging.js
@@ -1,3 +1,6 @@
+// Provide an easy way for test suites to intercept calls to the logging library.
+// To use, a suite can store the result of calling `stubLogger` in a setup "test",
+// and then pass this result to `restoreLogger` in a cleanup "test".
 const sinon = require('sinon');
 const Logger = require('../../src/modules/logger');
 

--- a/tests/helpers/mock-message.js
+++ b/tests/helpers/mock-message.js
@@ -1,0 +1,35 @@
+const sinon = require('sinon');
+
+/**
+ * A facsimile of a Discord Message, for use in tests
+ * @param {Object} c Config object
+ * @param {'dm'|'group'|'text'} c.channelType Type of the channel the message was received in
+ * @param {Function} c.reactStub A stub for message#react
+ * @param {Function} c.replyStub A stub for message#reply
+ * @param {Function} c.sendStub A stub for message.channel#send
+ * @param {string} c.authorId A discord ID for the message's author
+ * @param {Object} c.clientStub An object representing the bot client
+ */
+const mockMessage = ({
+    channelType = 'dm',
+    reactStub = sinon.stub(),
+    replyStub = sinon.stub(),
+    sendStub = sinon.stub(),
+    authorId = '123456789',
+    clientStub = {},
+} = {}) => {
+    const clientWithSettings = Object.assign({}, { settings: { botPrefix: '-mh' } }, clientStub);
+    const stub = {
+        client: clientWithSettings,
+        author: { id: authorId },
+        channel: {
+            type: channelType,
+            send: sendStub,
+        },
+        react: reactStub,
+        reply: replyStub,
+    };
+    return stub;
+};
+
+module.exports = mockMessage;

--- a/tests/modules/file-utils.js
+++ b/tests/modules/file-utils.js
@@ -4,17 +4,7 @@ const sinon = require('sinon');
 
 // Stub IO
 const fs = require('fs');
-const Logger = require('../../src/modules/logger');
-const stubLogger = () => {
-    return {
-        log: sinon.stub(Logger, 'log'),
-        warn: sinon.stub(Logger, 'warn'),
-        error: sinon.stub(Logger, 'error'),
-    };
-};
-const restoreLogger = ({ ...stubs }) => {
-    Object.values(stubs).forEach(stub => stub.restore());
-};
+const { stubLogger, restoreLogger } = require('../helpers/logging');
 let logStubs;
 
 // Functionality to be tested.

--- a/tests/modules/timers.js
+++ b/tests/modules/timers.js
@@ -1,22 +1,11 @@
 // Required test imports
 const test = require('tape');
-const sinon = require('sinon');
 
 // Functionality to be tested.
 const Timer = require('../../src/modules/timers');
 
 // Stub Logger methods to minimize crosstalk.
-const Logger = require('../../src/modules/logger');
-const stubLogger = () => {
-    return {
-        log: sinon.stub(Logger, 'log'),
-        warn: sinon.stub(Logger, 'warn'),
-        error: sinon.stub(Logger, 'error'),
-    };
-};
-const restoreLogger = ({ ...stubs }) => {
-    Object.values(stubs).forEach(stub => stub.restore());
-};
+const { stubLogger, restoreLogger } = require('../helpers/logging');
 
 test('Timer ctor', function (suite) {
     let logStubs;


### PR DESCRIPTION
 - moves logging stubs to tests/helpers
 - creates hunter registry stubs in tests/helpers
 - creates message mock method, for use by command tests
 - framework for testing iam, other commands

WIP, feel free to add tests.