### PR TITLE
If the name ended in 'a' it wasn't parsing ranks right

### DIFF
--- a/src/modules/hunter-registry.js
+++ b/src/modules/hunter-registry.js
@@ -232,7 +232,7 @@ async function populateHunter(discordId) {
         const description = dom.window.document.querySelector('meta[property=\'og:description\']').getAttribute('content');
         const lines = description.split('\n');
         // Pull the title from line 0
-        hunters[discordId]['rank'] = /an* (.*) in MouseHunt./.exec(lines[0])[1].toLowerCase() || 'unknown';
+        hunters[discordId]['rank'] = / an* (.*) in MouseHunt./.exec(lines[0])[1].toLowerCase() || 'unknown';
         hunters[discordId]['location'] = /Location: (.*)$/.exec(lines[5])[1].toLowerCase() || 'unknown';
         hunters[discordId]['failureCount'] = 0;
     } catch (error) {


### PR DESCRIPTION
Hotfix for hunter rank parsing