### PR TITLE
changed getFilter function to descern between '3_d' and '3_m'

### DIFF
--- a/src/modules/mhct-lookup.js
+++ b/src/modules/mhct-lookup.js
@@ -225,9 +225,9 @@ function getFilter(tester) {
     if (!tester)
         return;
     tester = `${tester}`;
-    if (tester.startsWith('3_d'))
+    if (tester.startsWith('3_d') || tester.startsWith('3d'))
         tester = '3_days';
-    else if (tester.startsWith('3_m'))
+    else if (tester.startsWith('3_m') || tester.startsWith('3m'))
         tester = '3_months';
     else if (tester.startsWith('all'))
         tester = 'alltime';

--- a/src/modules/mhct-lookup.js
+++ b/src/modules/mhct-lookup.js
@@ -225,8 +225,10 @@ function getFilter(tester) {
     if (!tester)
         return;
     tester = `${tester}`;
-    if (tester.startsWith('3'))
+    if (tester.startsWith('3_d'))
         tester = '3_days';
+    else if (tester.startsWith('3_m'))
+        tester = '3_months';
     else if (tester.startsWith('all'))
         tester = 'alltime';
     else if (tester === 'current') {

--- a/tests/modules/mhct-lookup.js
+++ b/tests/modules/mhct-lookup.js
@@ -36,7 +36,7 @@ test('getFilter', suite => {
             { input: '3_d', expected: '3_days' },
             { input: '3days', expected: '3_days' },
             { input: '3_m', expected: '3_months' },
-            { input: '3months', expected: '3_months'},
+            { input: '3months', expected: '3_months' },
             { input: 'all', expected: 'alltime' },
             { input: 'allowance', expected: 'alltime' },
             { input: 'current', expected: '1_month' }, //NOTE this can only be asserted because we don't load the filter list

--- a/tests/modules/mhct-lookup.js
+++ b/tests/modules/mhct-lookup.js
@@ -33,8 +33,10 @@ test('getFilter', suite => {
     });
     suite.test('given string input - returns known shortcuts', t => {
         const inputs = [
-            { input: '3', expected: '3_days' },
-            { input: '3day', expected: '3_days' },
+            { input: '3_d', expected: '3_days' },
+            { input: '3days', expected: '3_days' },
+            { input: '3_m', expected: '3_months' },
+            { input: '3months', expected: '3_months'},
             { input: 'all', expected: 'alltime' },
             { input: 'allowance', expected: 'alltime' },
             { input: 'current', expected: '1_month' }, //NOTE this can only be asserted because we don't load the filter list


### PR DESCRIPTION
addresses issue #215 

 changed from
```
if (tester.startsWith('3'))
        tester = '3_days';
```
to
```
if (tester.startsWith('3_d'))
        tester = '3_days';
    else if (tester.startsWith('3_m'))
        tester = '3_months';
```
in order to properly discern between months and days as mentioned above.