### PR TITLE
feat(find,ifind): Allow the first non-command token to be used as the filter search term

### DIFF
--- a/src/commands/find.js
+++ b/src/commands/find.js
@@ -4,16 +4,16 @@ const { Message, Util } = require('discord.js');
 const CommandResult = require('../interfaces/command-result');
 const { isDMChannel } = require('../modules/channel-utils');
 const Logger = require('../modules/logger');
-const { initialize, getFilter, getMice, formatMice, sendInteractiveSearchResult,
+const { initialize, extractEventFilter, getMice, formatMice, sendInteractiveSearchResult,
     listFilters, getLoot, formatLoot, save } = require('../modules/mhct-lookup');
 
 /**
  *
  * @param {Message} message The message that triggered the action
- * @param {string[]} tokens The tokens of the command
+ * @param {string[]} userArgs The tokens of the command
  * @returns {Promise<CommandResult>} Status of the execution
  */
-async function doFIND(message, tokens) {
+async function doFIND(message, userArgs) {
     const theResult = new CommandResult({ message, success: false, sentDM: false });
     let reply = '';
     const opts = {};
@@ -22,24 +22,13 @@ async function doFIND(message, tokens) {
         uri: 'https://www.mhct.win/attractions.php',
         type: 'mouse',
     };
-    if (!tokens)
+    if (!userArgs)
         reply = 'I just cannot find what you\'re looking for (since you didn\'t tell me what it was).';
     else {
+        const { tokens, filter } = extractEventFilter(userArgs);
         // Set the filter if it's requested.
-        if (tokens.includes('-e')) {
-            const introducerIndex = tokens.findIndex((token) => token === '-e');
-            // The index of the filter term must immediately follow the introducer token.
-            const filterIndex = introducerIndex + 1;
-            let spliceCount = 1;
-            if (filterIndex < tokens.length) {
-                const filter = getFilter(tokens[filterIndex]);
-                if (filter && tokens.length > 2) {
-                    opts.timefilter = filter.code_name;
-                    ++spliceCount;
-                }
-            }
-            // Remove the processed tokens.
-            tokens.splice(introducerIndex, spliceCount);
+        if (filter) {
+            opts.timefilter = filter.code_name;
         }
 
         // Figure out what they're searching for

--- a/tests/modules/mhct-lookup.js
+++ b/tests/modules/mhct-lookup.js
@@ -5,13 +5,19 @@ const searchHelper = require('../../src/modules/search-helpers');
 const getSearchedEntityStub = sinon.stub(searchHelper, 'getSearchedEntity');
 const mhct_lookup = require('../../src/modules/mhct-lookup');
 
-//const getMHCTList = mhct_lookup.getMHCTList;
-//const findThing = mhct_lookup.findThing;
-const getFilter = mhct_lookup.getFilter;
-const getLoot = mhct_lookup.getLoot;
-const getMice = mhct_lookup.getMice;
-const getConvertibles = mhct_lookup.getConvertibles;
-//const formatLoot = mhct_lookup.formatLoot;
+const {
+    extractEventFilter,
+    // findThing,
+    // formatConvertibles,
+    // formatLoot,
+    // formatMice,
+    getConvertibles,
+    getFilter,
+    getLoot,
+    getMice,
+    // getMinluckString,
+    // getMHCTList,
+} = mhct_lookup;
 
 
 test('getFilter', suite => {
@@ -23,9 +29,11 @@ test('getFilter', suite => {
             () => {},
         ];
         t.plan(inputs.length * 2);
+        getSearchedEntityStub.returns([{ code_name: 1 }]);
         inputs.forEach(input => {
-            t.equal(getFilter(input), undefined, `should return undefined for non-string ${typeof input}`);
+            const result = getFilter(input);
             t.false(getSearchedEntityStub.called, 'should not call "getSearchedEntity"');
+            t.equal(result, undefined, `should return undefined for non-string ${typeof input}`);
         });
     });
 
@@ -49,7 +57,9 @@ test('getFilter', suite => {
             getSearchedEntityStub.resetHistory();
         });
     });
+});
 
+test('getLoot', suite => {
     suite.test('given input that can\'t be turned into a truthy string - returns undefined', t => {
         t.teardown(() => sinon.reset());
         const inputs = [
@@ -63,7 +73,9 @@ test('getFilter', suite => {
             `should return undefined for random and empty stuff - ${typeof input}`,
         ));
     });
+});
 
+test('getMice', suite => {
     suite.test('given input that can\'t be turned into a truthy string - returns undefined', t => {
         t.teardown(() => sinon.reset());
         const inputs = [
@@ -110,6 +122,82 @@ test('getConvertibles', suite => {
             // TODO: mock initialize `convertibles` to assert the right array is used. Requires stubbing `getMHCTList` or `fetch`
             t.true(Array.isArray(callArgs[1]), 'should pass convertible "db" as second arg');
             getSearchedEntityStub.resetHistory();
+        });
+    });
+});
+
+test('extractEventFilter', suite => {
+    const mockResults = [{ code_name: 'first' }, { code_name: 'second' }];
+    const filterToken = 'matched';
+    // Can't stub out `getFilter` as it is accessed internally, so need to rely on its behavior.
+    getSearchedEntityStub.returns([]);
+    getSearchedEntityStub.withArgs(filterToken, sinon.match.array).returns(mockResults);
+    suite.teardown(() => getSearchedEntityStub.reset());
+
+    suite.test('given no tokens - returns no filter', t => {
+        t.teardown(() => sinon.resetHistory());
+        t.plan(1);
+        const input = [];
+        const result = extractEventFilter(input);
+        t.strictEqual(result.filter, null, 'should not find filter');
+    });
+
+    suite.test('given tokens - when "-e" flag not present - uses first token as filter search term', t => {
+        t.teardown(() => sinon.resetHistory());
+        t.plan(3);
+        const input = ['tryMe', 'as', 'a', 'filter', 'identifier'];
+        const result = extractEventFilter(input);
+        t.true(getSearchedEntityStub.called, 'should call "getFilter" and thus "getSearchedEntity"');
+        t.deepEqual(getSearchedEntityStub.getCall(0).args[0], 'tryMe', 'should search for filter matching first token');
+        t.notStrictEqual(result.tokens, input, 'should return new array of tokens');
+    });
+
+    suite.test('given tokens - when "-e" flag not present - when filter found - returns tokens without search term', t => {
+        t.teardown(() => sinon.resetHistory());
+        t.plan(3);
+        const input = [filterToken, 'leave', 'us', 'be'];
+        const result = extractEventFilter(input);
+        t.true(getSearchedEntityStub.called, 'should call "getFilter" and thus "getSearchedEntity"');
+        t.ok(result.filter, 'should have found filter');
+        t.deepEqual(result.tokens, input.slice(1), 'should return unused tokens');
+    });
+
+    suite.test('given tokens - when "-e" flag not present - when filter not found - no tokens consumed', t => {
+        t.teardown(() => sinon.resetHistory());
+        t.plan(3);
+        const input = ['leave', 'us', 'be'];
+        const result = extractEventFilter(input);
+        t.true(getSearchedEntityStub.called, 'should call "getFilter" and thus "getSearchedEntity"');
+        t.notOk(result.filter, 'should not have found filter');
+        t.deepEqual(result.tokens, input, 'should not consume any tokens');
+    });
+
+    [filterToken, 'not matched'].forEach((followingToken) => {
+        const prefix = `given tokens with "-e" flag - when filter ${followingToken}`;
+        suite.test(`${prefix} - removes flag from returned tokens`, t => {
+            t.teardown(() => sinon.resetHistory());
+            t.plan(1);
+            const input = ['noTouchy', '-e', followingToken, 'alsoNoTouchy'];
+            const result = extractEventFilter(input);
+            t.notOk(result.tokens.find((token) => token === '-e'), 'should remove "-e" token from returned tokens');
+        });
+
+        suite.test(`${prefix} - removes following token too`, t => {
+            t.teardown(() => sinon.resetHistory());
+            t.plan(2);
+            const input = ['noTouchy', '-e', followingToken, 'alsoNoTouchy'];
+            const result = extractEventFilter(input);
+            t.notOk(result.tokens.find((token) => token === followingToken), 'should remove "-e" token from returned tokens');
+            t.deepEqual(result.tokens, ['noTouchy', 'alsoNoTouchy'], 'should return unused tokens in correct order');
+        });
+
+        suite.test(`${prefix} - when following token - following token is the search term`, t => {
+            t.teardown(() => sinon.resetHistory());
+            t.plan(2);
+            const input = ['noTouchy', '-e', followingToken, 'alsoNoTouchy'];
+            const result = extractEventFilter(input);
+            t.true(getSearchedEntityStub.called, 'should call "getFilter" and thus "getSearchedEntity"');
+            t.strictEqual(getSearchedEntityStub.getCall(0).args[0], followingToken, 'should use token after "-e" as filter search term');
         });
     });
 });

--- a/tests/modules/mhct-lookup.js
+++ b/tests/modules/mhct-lookup.js
@@ -195,10 +195,19 @@ test('extractEventFilter', suite => {
             t.teardown(() => sinon.resetHistory());
             t.plan(2);
             const input = ['noTouchy', '-e', followingToken, 'alsoNoTouchy'];
-            const result = extractEventFilter(input);
+            extractEventFilter(input);
             t.true(getSearchedEntityStub.called, 'should call "getFilter" and thus "getSearchedEntity"');
             t.strictEqual(getSearchedEntityStub.getCall(0).args[0], followingToken, 'should use token after "-e" as filter search term');
         });
+    });
+
+    suite.test('given tokens with "-e" - when no following token - no search performed', t => {
+        t.teardown(() => sinon.resetHistory());
+        t.plan(2);
+        const input = ['noTouchy', 'seriouslyNoTouchy', '-e'];
+        const result = extractEventFilter(input);
+        t.false(getSearchedEntityStub.called, 'should not perform filter lookup');
+        t.deepEqual(result.tokens, ['noTouchy', 'seriouslyNoTouchy'], 'should always remove "-e" token');
     });
 });
 


### PR DESCRIPTION
Closes #242 

 - Replaces the duplicated code with a shared method that processes the given tokens
 - fixes bug (quirk?) where the token following `-e` was included in the search if it did not match a filter
   - `-mh find -e now snowflake` now results in searching for "snowflake", previously searched for "now snowflake"